### PR TITLE
Auto buy adventure stats, merge blacklist, some fixes

### DIFF
--- a/NGUInjector/Main.cs
+++ b/NGUInjector/Main.cs
@@ -298,56 +298,56 @@ namespace NGUInjector
                         MergeBlacklist = new int[] { }
                     };
 
-                Settings.MassUpdate(temp);
+                    Settings.MassUpdate(temp);
 
-                Log($"Created default settings");
-            }
+                    Log($"Created default settings");
+                }
 
                 settingsForm = new SettingsForm();
 
-            if (string.IsNullOrEmpty(Settings.AllocationFile))
-            {
-                Settings.SetSaveDisabled(true);
-                Settings.AllocationFile = "default";
-                Settings.SetSaveDisabled(false);
-            }
+                if (string.IsNullOrEmpty(Settings.AllocationFile))
+                {
+                    Settings.SetSaveDisabled(true);
+                    Settings.AllocationFile = "default";
+                    Settings.SetSaveDisabled(false);
+                }
 
-            if (Settings.TitanGoldTargets == null || Settings.TitanGoldTargets.Length == 0)
-            {
-                Settings.SetSaveDisabled(true);
-                Settings.TitanGoldTargets = new bool[ZoneHelpers.TitanZones.Length];
-                Settings.SetSaveDisabled(false);
-            }
+                if (Settings.TitanGoldTargets == null || Settings.TitanGoldTargets.Length == 0)
+                {
+                    Settings.SetSaveDisabled(true);
+                    Settings.TitanGoldTargets = new bool[ZoneHelpers.TitanZones.Length];
+                    Settings.SetSaveDisabled(false);
+                }
 
-            if (Settings.TitanMoneyDone == null || Settings.TitanMoneyDone.Length == 0)
-            {
-                Settings.SetSaveDisabled(true);
-                Settings.TitanMoneyDone = new bool[ZoneHelpers.TitanZones.Length];
-                Settings.SetSaveDisabled(false);
-            }
+                if (Settings.TitanMoneyDone == null || Settings.TitanMoneyDone.Length == 0)
+                {
+                    Settings.SetSaveDisabled(true);
+                    Settings.TitanMoneyDone = new bool[ZoneHelpers.TitanZones.Length];
+                    Settings.SetSaveDisabled(false);
+                }
 
-            if (Settings.TitanSwapTargets == null || Settings.TitanSwapTargets.Length == 0)
-            {
-                Settings.SetSaveDisabled(true);
-                Settings.TitanSwapTargets = new bool[ZoneHelpers.TitanZones.Length];
-                Settings.SetSaveDisabled(false);
-            }
+                if (Settings.TitanSwapTargets == null || Settings.TitanSwapTargets.Length == 0)
+                {
+                    Settings.SetSaveDisabled(true);
+                    Settings.TitanSwapTargets = new bool[ZoneHelpers.TitanZones.Length];
+                    Settings.SetSaveDisabled(false);
+                }
 
-            if (Settings.SpecialBoostBlacklist == null)
-            {
-                Settings.SetSaveDisabled(true);
-                Settings.SpecialBoostBlacklist = new int[0];
-                Settings.SetSaveDisabled(false);
-            }
+                if (Settings.SpecialBoostBlacklist == null)
+                {
+                    Settings.SetSaveDisabled(true);
+                    Settings.SpecialBoostBlacklist = new int[0];
+                    Settings.SetSaveDisabled(false);
+                }
 
-            if (Settings.BlacklistedBosses == null)
-            {
-                Settings.SetSaveDisabled(true);
-                Settings.BlacklistedBosses = new int[0];
-                Settings.SetSaveDisabled(false);
-            }
+                if (Settings.BlacklistedBosses == null)
+                {
+                    Settings.SetSaveDisabled(true);
+                    Settings.BlacklistedBosses = new int[0];
+                    Settings.SetSaveDisabled(false);
+                }
 
-            WishManager = new WishManager();
+                WishManager = new WishManager();
 
                 LoadAllocation();
                 LoadAllocationProfiles();

--- a/NGUInjector/Managers/CardManager.cs
+++ b/NGUInjector/Managers/CardManager.cs
@@ -25,7 +25,7 @@ namespace NGUInjector.Managers
                 _maxManas = _character.cardsController.maxManaGenSize();
                 foreach (cardBonus bonus in Enum.GetValues(typeof(cardBonus)))
                 {
-                    float bonusValue = _cardsController.generateCardEffect(bonus, 3, 1, 1, false);
+                    float bonusValue = _cardsController.generateCardEffect(bonus, 6, 1, 1, false);
                     _cardValues.Add(bonus, bonusValue);
                 }
             }
@@ -123,9 +123,25 @@ namespace NGUInjector.Managers
                         while (id < _cards.cards.Count)
                         {
                             Card _card = _cards.cards[id];
-                            if (_card.bonusType != cardBonus.adventureStat || _card.bonusType == cardBonus.adventureStat && Main.Settings.TrashAdventureCards)
+
+                            if (_card.bonusType != cardBonus.adventureStat || (_card.bonusType == cardBonus.adventureStat && Main.Settings.TrashAdventureCards))
                             {
-                                if ((int)_cards.cards[id].cardRarity <= Main.Settings.CardsTrashQuality - 1)
+                                if(_card.type == cardType.end)
+                                {
+                                    if (Main.Character.inventory.accessories.Any(c => c.id == 492))
+                                    {
+                                        _cardsController.trashCard(id);
+                                        Main.LogCard($"Trashed Card: Bonus Type: END, due to already having the END piece");
+                                        continue;
+                                    }
+                                    else if (_cards.cards.Count(c => c.type == cardType.end) > 1)
+                                    {
+                                        _cardsController.trashCard(id);
+                                        Main.LogCard($"Trashed Card: Bonus Type: END, due to already having one in the cards list");
+                                        continue;
+                                    }
+                                }
+                                else if ((int)_cards.cards[id].cardRarity <= Main.Settings.CardsTrashQuality - 1)
                                 {
                                     Main.LogCard($"Trashed Card: Cost: {_card.manaCosts.Sum()} Rarity: {_card.cardRarity} Bonus Type: {_card.bonusType}, due to Quality settings");
                                     if (_card.isProtected) _card.isProtected = false;
@@ -270,6 +286,10 @@ namespace NGUInjector.Managers
 
             if (priority.ToUpper() == "NORMALVALUE")
             {
+                if(c1.bonusType == c2.bonusType)
+                {
+                    return getCardValue(c2).CompareTo(getCardValue(c1));
+                }
                 return getCardNormalValue(c2).CompareTo(getCardNormalValue(c1));
             }
 

--- a/NGUInjector/Managers/InventoryManager.cs
+++ b/NGUInjector/Managers/InventoryManager.cs
@@ -317,7 +317,7 @@ namespace NGUInjector.Managers
         internal void MergeInventory(ih[] ci)
         {
             var grouped =
-                ci.Where(x => x.id >= 40 && x.level < 100 && !_mergeBlacklist.Contains(x.id) && !_guffs.Contains(x.id) && (x.id < 278 || x.id > 287)).GroupBy(x => x.id).Where(x => x.Count() > 1);
+                ci.Where(x => x.id >= 40 && x.level < 100 && !_mergeBlacklist.Contains(x.id) && !Settings.MergeBlacklist.Contains(x.id) && !_guffs.Contains(x.id) && (x.id < 278 || x.id > 287)).GroupBy(x => x.id).Where(x => x.Count() > 1);
 
             foreach (var item in grouped)
             {

--- a/NGUInjector/Managers/LoadoutManager.cs
+++ b/NGUInjector/Managers/LoadoutManager.cs
@@ -390,7 +390,7 @@ namespace NGUInjector.Managers
                 .Where(x => x.id == id && x.equipment.isEquipment()).ToArray();
             if (items.Length != 0)
             {
-                return moneyPit ? items.OrderByDescending(x => x.level).First() : items.MaxItem();
+                return moneyPit ? items.OrderByDescending(x => x.level == 100 ? 0 : x.level).First() : items.MaxItem();
             }
 
             return null;

--- a/NGUInjector/Managers/WishManager.cs
+++ b/NGUInjector/Managers/WishManager.cs
@@ -104,7 +104,7 @@ namespace NGUInjector.Managers
         {
             if (Settings.WishSortOrder)
             {
-                return _character.wishesController.wishSpeedDivider(wishId);
+                return _character.wishesController.wishSpeedDivider(wishId) * (1f - _character.wishes.wishes[wishId].progress);
             }
             return _character.wishesController.properties[wishId].wishSpeedDivider;
         }

--- a/NGUInjector/SavedSettings.cs
+++ b/NGUInjector/SavedSettings.cs
@@ -57,6 +57,7 @@ namespace NGUInjector
         [SerializeField] private int _bloodMacGuffinAThreshold;
         [SerializeField] private int _bloodMacGuffinBThreshold;
         [SerializeField] private bool _autoBuyEm;
+        [SerializeField] private bool _autoBuyAdventure;
         [SerializeField] private double _bloodNumberThreshold;
         [SerializeField] private int[] _quickLoadout;
         [SerializeField] private int[] _quickDiggers;
@@ -114,6 +115,7 @@ namespace NGUInjector
         [SerializeField] private bool _manageConsumables;
         [SerializeField] private bool _autoBuyConsumables;
         [SerializeField] private bool _doMove69;
+        [SerializeField] private int[] _mergeBlacklist;
 
         private readonly string _savePath;
         private bool _disableSave;
@@ -224,6 +226,7 @@ namespace NGUInjector
             _bloodMacGuffinAThreshold = other.BloodMacGuffinAThreshold;
             _bloodMacGuffinBThreshold = other.BloodMacGuffinBThreshold;
             _autoBuyEm = other.AutoBuyEM;
+            _autoBuyAdventure = other.AutoBuyAdventure;
             _bloodNumberThreshold = other.BloodNumberThreshold;
             _quickDiggers = other.QuickDiggers;
             _quickLoadout = other.QuickLoadout;
@@ -296,6 +299,7 @@ namespace NGUInjector
             _manageConsumables = other._manageConsumables;
             _autoBuyConsumables = other._autoBuyConsumables;
             _doMove69 = other._doMove69;
+            _mergeBlacklist = other._mergeBlacklist;
         }
 
         public int SnipeZone
@@ -768,6 +772,17 @@ namespace NGUInjector
             {
                 if (value == _autoBuyEm) return;
                 _autoBuyEm = value;
+                SaveSettings();
+            }
+        }
+
+        public bool AutoBuyAdventure
+        {
+            get => _autoBuyAdventure;
+            set
+            {
+                if (value == _autoBuyAdventure) return;
+                _autoBuyAdventure = value;
                 SaveSettings();
             }
         }
@@ -1381,6 +1396,16 @@ namespace NGUInjector
             {
                 if (value == _doMove69) return;
                 _doMove69 = value;
+                SaveSettings();
+            }
+        }
+
+        public int[] MergeBlacklist
+        {
+            get => _mergeBlacklist;
+            set
+            {
+                _mergeBlacklist = value;
                 SaveSettings();
             }
         }

--- a/readme.MD
+++ b/readme.MD
@@ -48,6 +48,7 @@ To access these settings, open the **settings.json** (in your Desktop folder, me
 - **_questLoadout** - Assign your questing loadout here. Follow similar pattern as other loadout fields (example: [257, 170, 293, 236])
 - **_manageConsumables** - Set this to true to have injector manage consumables via breakpoints in your allocation file (see Section on Consumables below for details)
 - **_autoBuyConsumables** - Set this to true to have the injector auto purchase any consumables you try to use that you do not own. Will only buy consumables if you have the AP to purchase them.
+- **_autoBuyAdventure** - Set to true to auto purchase adventure stats. Will buy anything in the "Adventure Stats" tab that has a custom value set above 0 in a group, together with the EMR purchases (if enabled) once there is enough EXP to buy everything.
 - **_wishBlacklist** - Assign wishes you never want to cast here. Any which in this list will be ignored when working out the wish priorities (example: [131, 132, 128, 135,139]
 - **_cardSortEnabled** - Set this to true to have the injector sort cards based on the priorities given in **_cardSortOrder**. (**false** by default).
 - **_cardSortOrder** - Give a list of priorities to sort the cards by. The cards will be sorted by the first priority, then any cards that match will be sorted by the second priority, and so on. The available priority options are:


### PR DESCRIPTION
1. Auto purchasing adventure stats (works the same as EMR3)
3. Keep one END card even if it is matches card trashing rules
4. Slight card sorting improvent